### PR TITLE
feat : 메인 페이지 배너 api 연동

### DIFF
--- a/moving/src/api/mainpageAPI.tsx
+++ b/moving/src/api/mainpageAPI.tsx
@@ -1,7 +1,9 @@
 import { shuffleArray } from '@/auth/shuffleArray';
 import { authAxiosInstance } from '@/lib/axiosInstance';
-import { defaultMoviePageType, defaultMovieType } from '@/types/defaultMovie';
-import { Result } from 'postcss';
+import {
+  defaultMoviePageType,
+  defaultMovieType,
+} from '@/types/mainPage/defaultMovie';
 
 //이번주 트랜드 GET
 export const fetchWeekTrend = async () => {
@@ -20,9 +22,9 @@ export const fetchGameMovie = async () => {
 };
 
 // 미개봉 신작영화 GET
-export const fetchComingSoonMovies = async () => {
+export const fetchUpcomingMovie = async () => {
   const response = await authAxiosInstance.get(
-    'movie/upcoming?language=ko&page=1'
+    'movie/upcoming?language=ko&page=1&region=KR'
   );
   return response.data;
 };
@@ -32,7 +34,7 @@ export const fetchPopular = async () => {
   const response = await authAxiosInstance.get(
     'movie/popular?language=ko&page=1'
   );
-  return response.data.results;
+  return response.data;
 };
 
 // 명장 시리즈 GET
@@ -41,7 +43,7 @@ export const fetchSeries = async (): Promise<defaultMoviePageType> => {
   const movies = await fetchPopular();
 
   const moviesWithCollections = await Promise.all(
-    movies.map(async (movie: defaultMovieType) => {
+    movies.results.map(async (movie: defaultMovieType) => {
       const detail = await authAxiosInstance
         .get(`movie/${movie.id}`)
         .catch(() => null);
@@ -91,4 +93,4 @@ export const fetchToday = async () => {
 };
 
 // 이미지 사용할때 기본 URL
-export const BASE_IMAGE_URL = 'https://image.tmdb.org/t/p/w500';
+export const BASE_IMAGE_URL = process.env.NEXT_PUBLIC_BACK_IMAGE_URL;

--- a/moving/src/api/mainpageBanner.tsx
+++ b/moving/src/api/mainpageBanner.tsx
@@ -1,0 +1,28 @@
+import { authAxiosInstance } from '@/lib/axiosInstance';
+import { fetchMovieIDProps } from '@/types/mainPage/defaultMovie';
+
+// 신작 영화들 - 배너 부분
+export const fetchRecommendation = async () => {
+  const response = await authAxiosInstance.get(
+    'movie/now_playing?language=ko&page=1&region=KR'
+  );
+  return response.data;
+};
+
+// 감독 정보
+export const fetchDirector = async ({ movieId }: fetchMovieIDProps) => {
+  const response = await authAxiosInstance.get(
+    `movie/${movieId}/credits?language=ko`
+  );
+  return response.data;
+};
+
+// 비디오 api 가져와서 키값 가져오기
+export const fetchVideos = async ({ movieId }: fetchMovieIDProps) => {
+  const response = await authAxiosInstance.get(
+    `movie/${movieId}/videos?language=ko`
+  );
+  return response.data;
+};
+
+// 키값 가져오면 그 키값으로 iframe으로 동영상 재생 시키면됨

--- a/moving/src/auth/shuffleArray.ts
+++ b/moving/src/auth/shuffleArray.ts
@@ -1,4 +1,4 @@
-import { defaultMovieType } from '@/types/defaultMovie';
+import { defaultMovieType } from '@/types/mainPage/defaultMovie';
 
 export const shuffleArray = (array: defaultMovieType[]) => {
   for (let i = array.length - 1; i > 0; i--) {

--- a/moving/src/components/mainPage/ComingSoonMovies.tsx
+++ b/moving/src/components/mainPage/ComingSoonMovies.tsx
@@ -1,66 +1,40 @@
+import { BASE_IMAGE_URL } from '@/api/mainpageAPI';
+import { useUpcomingMovie } from '@/hook/useUpcomingMovie';
+import dayjs from 'dayjs';
 import Image from 'next/image';
-import StarIcon from '@/icons/starIcon.svg';
-
-const posterData = [
-  {
-    id: 1,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 2,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 3,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 4,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 5,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-];
 
 export default function BeforeOpening() {
+  const { data, isLoading, isError } = useUpcomingMovie();
+
+  const limited = data?.results.slice(0, 5);
+
+  if (isLoading) {
+    <div>로딩중</div>;
+  }
+
+  if (isError) {
+    <div>네트워크 에러1</div>;
+  }
+
   return (
     <section className="mx-[8.5vw] mt-[72px] flex flex-col">
       <h2 className="mb-7 text-2xl font-bold">❓곧 공개되는 신작영화</h2>
-      <ul className="flex gap-[60px]">
-        {posterData.map((poster) => (
-          <li key={poster.id} className="relative h-auto max-w-[272px] ">
-            <Image
-              src={poster.src}
-              width={272}
-              height={356}
-              alt="세로 포스터"
-              className="rounded-md blur-[1px] "
-            />
+      <ul className="flex justify-between">
+        {limited?.map((poster) => (
+          <li key={poster.id} className="relative h-auto max-w-[14.53vw] ">
+            <div className="relative h-[18.54vw] w-[14.53vw] ">
+              <Image
+                src={`${BASE_IMAGE_URL}${poster.poster_path}`}
+                layout="fill"
+                alt="세로 포스터"
+                className="rounded-2xl blur-[1px] "
+              />
+            </div>
             <div className="absolute inset-0 flex items-center justify-center rounded-2xl border border-[#f2b42e] bg-black text-[1vw] text-[#f2b42e] opacity-80">
               <span className="mr-2 font-light">Released at</span>
-              <span className="font-medium">2024 · 12</span>
+              <span className="font-medium">
+                {dayjs(poster.release_date).format('YYYY · MM')}
+              </span>
             </div>
           </li>
         ))}

--- a/moving/src/components/mainPage/MainBanner.tsx
+++ b/moving/src/components/mainPage/MainBanner.tsx
@@ -1,0 +1,92 @@
+import Image from 'next/image';
+import LeftArrow from '@/icons/left-arrow-Icon.svg';
+import RightArrow from '@/icons/right-arrow-Icon.svg';
+import {
+  useDirector,
+  useRecommendationMovie,
+} from '@/hook/useRecommendationMovie';
+import { BASE_IMAGE_URL } from '@/api/mainpageAPI';
+import { CrewMember } from '@/types/mainPage/mainbanner';
+import { useVideos } from '@/hook/useVideos';
+
+export default function MainBanner() {
+  const { data: bannerImage, isLoading, isError } = useRecommendationMovie();
+
+  const limitedData = bannerImage?.results.slice(0, 4);
+  const movieId = limitedData ? limitedData[0].id : null;
+  const { data: directorData } = useDirector(movieId ?? 0);
+  const { data: videoData } = useVideos(movieId ?? 0);
+
+  const director = directorData?.crew?.find(
+    (person: CrewMember) => person.job === 'Director'
+  );
+
+  if (isLoading) {
+    return <div> 로딩중</div>;
+  }
+
+  if (isError) {
+    return <div>네트워크 에러</div>;
+  }
+
+  if (!limitedData || limitedData.length === 0) {
+    return <div>추천영화가 없습니다.</div>;
+  }
+
+  return (
+    <section className="">
+      <div className="relative h-auto w-full">
+        <div
+          className="absolute inset-0 
+      bg-gradient-to-t from-[#131518] to-[rgba(59,63,69,0)]"
+        />
+        <div className="flex h-[708px] w-full items-center justify-center overflow-hidden">
+          <iframe
+            width={3320}
+            height={1538}
+            src={`https://www.youtube.com/embed/${videoData?.results[0].key}?autoplay=1&mute=1&controls=0&modestbranding=1&rel=0`}
+            title={videoData?.results[0].name}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          />
+        </div>
+
+        {/* <Image
+          src={'/images/mainBanner.png'}
+          layout="responsive" // 반응형 크기 조정
+          width={1920} // 원본 이미지 너비
+          height={708} // 원본 이미지 높이
+          alt="메인 베너"
+        /> */}
+        <div className="absolute bottom-0 mx-[8.5vw] text-center text-white">
+          <h1 className="flex flex-col gap-2 text-start text-white ">
+            <span className="ml-1 text-base">{director?.name}</span>
+            <span className="text-[3.1vw] font-semibold">
+              {limitedData[0].title}
+            </span>
+          </h1>
+          <ul className="relative flex gap-[2.45vw]">
+            <div className="absolute left-[-25px] top-[50%] flex h-[50px] w-[50px] -translate-y-1/2 transform items-center justify-center rounded-full bg-white">
+              <LeftArrow />
+            </div>
+            {limitedData?.map((poster) => (
+              <li className="h-auto max-w-[358px]">
+                <Image
+                  key={poster.id}
+                  src={`${BASE_IMAGE_URL}${poster.backdrop_path}`}
+                  width={358}
+                  height={190}
+                  alt="가로 이미지"
+                  className=" rounded-2xl"
+                />
+              </li>
+            ))}
+
+            <div className="absolute right-[-25px] top-[50%] flex h-[50px] w-[50px] -translate-y-1/2 transform items-center justify-center rounded-full bg-white">
+              <RightArrow />
+            </div>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/moving/src/components/mainPage/gameMovie.tsx
+++ b/moving/src/components/mainPage/gameMovie.tsx
@@ -28,7 +28,7 @@ export default function GameMovie() {
   }
 
   if (isError) {
-    return <div> 네트워크 에러</div>;
+    return <div> 네트워크 에러2</div>;
   }
 
   return (

--- a/moving/src/components/mainPage/popularMovies.tsx
+++ b/moving/src/components/mainPage/popularMovies.tsx
@@ -1,122 +1,56 @@
 import Image from 'next/image';
 import RightArrow from '@/icons/right-arrow-white.svg';
 import EyesIcon from '@/icons/eyesIcon.svg';
-
-const posterData = [
-  {
-    id: 1,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 2,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 3,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 4,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 5,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 6,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 7,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 8,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 9,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 10,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-];
+import { usePopularMovie } from '@/hook/usePopularMovie';
+import { BASE_IMAGE_URL } from '@/api/mainpageAPI';
 
 export default function PopularMovies() {
+  const { data, isLoading, isError } = usePopularMovie();
+
+  if (isLoading) {
+    return <div> 로딩중</div>;
+  }
+
+  if (isError) {
+    return <div> 네트워크 에러2</div>;
+  }
+
+  const limited = data?.results.slice(0, 10);
+
   return (
-    <section className="ml-[160px] mt-[72px] flex flex-col overflow-hidden">
+    <section className="ml-[8.5vw] mt-[72px] flex flex-col overflow-hidden">
       <h2 className="mb-12 text-2xl font-bold">🏆 인기 영화 TOP 10</h2>
-      <ul className="relative flex gap-[40px] ">
-        {posterData.map((poster, index) => (
+      <ul className="relative flex gap-[2vw] ">
+        {limited?.map((poster, index) => (
           <li
             key={poster.id}
-            className="relative h-[199px] w-[359px] shrink-0 overflow-visible"
+            className="relative h-[10.4vw] w-[18.7vw] shrink-0 overflow-visible "
           >
             <Image
-              src={poster.src}
+              src={`${BASE_IMAGE_URL}${poster.backdrop_path}`}
               layout="fill" // 부모의 크기에 맞춤
               objectFit="cover" // 부모 크기에 맞게 자름
               alt="세로 포스터"
+              className="rounded-2xl"
             />
-            <div className="absolute inset-0 bg-black opacity-50" />
+            <div className="absolute inset-0 rounded-2xl bg-black opacity-50" />
             <div className="absolute left-2 top-[-30px] text-5xl font-black italic text-white">
               {index + 1}
             </div>
             <div className="absolute inset-0 flex flex-col justify-between p-4">
               <div className="flex items-center justify-end gap-1">
-                <EyesIcon /> <span className="text-sm font-normal">2.4k</span>
+                <EyesIcon />
+                <span className="text-sm font-normal">{poster.vote_count}</span>
               </div>
-
               <div className="flex justify-between">
-                <span className="text-xl font-semibold">
-                  엘리멘탈: 재미있어!
+                <span className="w-[12vw] truncate text-xl font-semibold">
+                  {poster.title}
                 </span>
                 <div>
-                  <span className="text-base font-medium">4.9</span>{' '}
-                  <span>(396)</span>
+                  <span className="text-base font-medium">
+                    {poster.vote_average.toFixed(1)}
+                  </span>
+                  <span>{`(${poster.vote_count})`}</span>
                 </div>
               </div>
             </div>

--- a/moving/src/components/mainPage/series.tsx
+++ b/moving/src/components/mainPage/series.tsx
@@ -6,57 +6,6 @@ import { useEffect } from 'react';
 import { BASE_IMAGE_URL } from '@/api/mainpageAPI';
 import dayjs from 'dayjs';
 
-const posterData = [
-  {
-    id: 1,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 2,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 3,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 4,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 5,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 6,
-    src: '/images/mainpage-length-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-];
-
 export default function Series() {
   const { genres, fetchGenres } = useGenreStore();
   const { data, isLoading, isError } = useSeriesMovie();
@@ -79,7 +28,7 @@ export default function Series() {
   }
 
   if (isError) {
-    return <div> 네트워크 에러</div>;
+    return <div> 네트워크 에러3</div>;
   }
 
   return (

--- a/moving/src/hook/useGameMovie.tsx
+++ b/moving/src/hook/useGameMovie.tsx
@@ -1,5 +1,5 @@
 import { fetchGameMovie } from '@/api/mainpageAPI';
-import { defaultMoviePageType } from '@/types/defaultMovie';
+import { defaultMoviePageType } from '@/types/mainPage/defaultMovie';
 import { useQuery } from '@tanstack/react-query';
 
 export const useGameMovie = () => {

--- a/moving/src/hook/usePopularMovie.tsx
+++ b/moving/src/hook/usePopularMovie.tsx
@@ -1,10 +1,10 @@
-import { fetchSeries } from '@/api/mainpageAPI';
+import { fetchPopular } from '@/api/mainpageAPI';
 import { defaultMoviePageType } from '@/types/mainPage/defaultMovie';
 import { useQuery } from '@tanstack/react-query';
 
-export const useSeriesMovie = () => {
+export const usePopularMovie = () => {
   return useQuery<defaultMoviePageType>({
-    queryKey: ['seriesMovie'],
-    queryFn: fetchSeries,
+    queryKey: ['popularMovie'],
+    queryFn: fetchPopular,
   });
 };

--- a/moving/src/hook/useRecommendationMovie.tsx
+++ b/moving/src/hook/useRecommendationMovie.tsx
@@ -1,0 +1,18 @@
+import { fetchDirector, fetchRecommendation } from '@/api/mainpageBanner';
+import { defaultMoviePageType } from '@/types/mainPage/defaultMovie';
+import { CreditsType, CrewMember } from '@/types/mainPage/mainbanner';
+import { useQuery } from '@tanstack/react-query';
+
+export const useRecommendationMovie = () => {
+  return useQuery<defaultMoviePageType>({
+    queryKey: ['recommendation'],
+    queryFn: fetchRecommendation,
+  });
+};
+
+export const useDirector = (movieId: number) => {
+  return useQuery<CreditsType>({
+    queryKey: ['Director', movieId],
+    queryFn: () => fetchDirector({ movieId }),
+  });
+};

--- a/moving/src/hook/useTodayMovie.tsx
+++ b/moving/src/hook/useTodayMovie.tsx
@@ -1,5 +1,5 @@
 import { fetchToday } from '@/api/mainpageAPI';
-import { defaultMoviePageType } from '@/types/defaultMovie';
+import { defaultMoviePageType } from '@/types/mainPage/defaultMovie';
 import { useQuery } from '@tanstack/react-query';
 
 export const useTodayMovie = () => {

--- a/moving/src/hook/useUpcomingMovie.tsx
+++ b/moving/src/hook/useUpcomingMovie.tsx
@@ -1,10 +1,10 @@
-import { fetchSeries } from '@/api/mainpageAPI';
+import { fetchUpcomingMovie } from '@/api/mainpageAPI';
 import { defaultMoviePageType } from '@/types/mainPage/defaultMovie';
 import { useQuery } from '@tanstack/react-query';
 
-export const useSeriesMovie = () => {
+export const useUpcomingMovie = () => {
   return useQuery<defaultMoviePageType>({
-    queryKey: ['seriesMovie'],
-    queryFn: fetchSeries,
+    queryKey: ['upcomingMovie'],
+    queryFn: fetchUpcomingMovie,
   });
 };

--- a/moving/src/hook/useVideos.tsx
+++ b/moving/src/hook/useVideos.tsx
@@ -1,0 +1,10 @@
+import { fetchVideos } from '@/api/mainpageBanner';
+import { VideoType } from '@/types/mainPage/mainbanner';
+import { useQuery } from '@tanstack/react-query';
+
+export const useVideos = (movieId: number) => {
+  return useQuery<VideoType>({
+    queryKey: ['Videos', movieId],
+    queryFn: () => fetchVideos({ movieId }),
+  });
+};

--- a/moving/src/hook/useWeekTrend.tsx
+++ b/moving/src/hook/useWeekTrend.tsx
@@ -1,5 +1,5 @@
 import { fetchWeekTrend } from '@/api/mainpageAPI';
-import { defaultMoviePageType } from '@/types/defaultMovie';
+import { defaultMoviePageType } from '@/types/mainPage/defaultMovie';
 import { useQuery } from '@tanstack/react-query';
 
 export const useWeekTrend = () => {

--- a/moving/src/lib/axiosInstance.tsx
+++ b/moving/src/lib/axiosInstance.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export const authAxiosInstance = axios.create({
-  baseURL: 'https://api.themoviedb.org/3/',
+  baseURL: process.env.NEXT_PUBLIC_BASE_URL,
   headers: {
     accept: 'application/json',
     Authorization:

--- a/moving/src/pages/mainPage/index.tsx
+++ b/moving/src/pages/mainPage/index.tsx
@@ -1,6 +1,3 @@
-import Image from 'next/image';
-import LeftArrow from '@/icons/left-arrow-Icon.svg';
-import RightArrow from '@/icons/right-arrow-Icon.svg';
 import WeeksTrend from '@/components/mainPage/weeksTrend';
 import GameMovie from '@/components/mainPage/gameMovie';
 import BeforeOpening from '@/components/mainPage/ComingSoonMovies';
@@ -13,88 +10,14 @@ import YoutubeIcon from '@/icons/youtubeIcon.svg';
 import XIcon from '@/icons/x(sns)Icon.svg';
 import TiktokIcon from '@/icons/tiktokIcon.svg';
 import InstarIcon from '@/icons/instagramIcon.svg';
-
-const posterData = [
-  {
-    id: 1,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 2,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 3,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-  {
-    id: 4,
-    src: '/images/mainpage-width-image.png',
-    title: 'The Green Mile',
-    year: '2016',
-    rating: '9.2',
-    genre: 'Biographical',
-  },
-];
+import MainBanner from '@/components/mainPage/MainBanner';
 
 export default function mainPage() {
   return (
     <>
       <main>
-        <section className="">
-          <div className="relative h-auto w-full">
-            <div
-              className="absolute inset-0 
-            bg-gradient-to-t from-[#131518] to-[rgba(59,63,69,0)]"
-            />
+        <MainBanner />
 
-            <Image
-              src={'/images/mainBanner.png'}
-              layout="responsive" // 반응형 크기 조정
-              width={1920} // 원본 이미지 너비
-              height={708} // 원본 이미지 높이
-              alt="메인 베너"
-            />
-            <div className="absolute bottom-0 mx-[8.5vw] text-center text-white">
-              <h1 className="flex flex-col gap-2 text-start text-white ">
-                <span className="ml-1 text-base">피터손 · 브렌다 슈에이</span>
-                <span className="text-6xl font-semibold">엘리멘탈</span>
-              </h1>
-              <ul className="relative flex gap-14">
-                <div className="absolute left-[-25px] top-[50%] flex h-[50px] w-[50px] -translate-y-1/2 transform items-center justify-center rounded-full bg-white">
-                  <LeftArrow />
-                </div>
-                {posterData.map((poster) => (
-                  <li className="h-auto max-w-[358px]">
-                    <Image
-                      key={poster.id}
-                      src={poster.src}
-                      width={358}
-                      height={190}
-                      alt="가로 이미지"
-                    />
-                  </li>
-                ))}
-
-                <div className="absolute right-[-25px] top-[50%] flex h-[50px] w-[50px] -translate-y-1/2 transform items-center justify-center rounded-full bg-white">
-                  <RightArrow />
-                </div>
-              </ul>
-            </div>
-          </div>
-        </section>
         <WeeksTrend />
 
         <GameMovie />

--- a/moving/src/types/mainPage/defaultMovie.ts
+++ b/moving/src/types/mainPage/defaultMovie.ts
@@ -20,3 +20,7 @@ export interface defaultMoviePageType {
   page: number; // 페이지번호
   results: defaultMovieType[]; // 영화목록
 }
+
+export interface fetchMovieIDProps {
+  movieId: number;
+}

--- a/moving/src/types/mainPage/mainbanner.ts
+++ b/moving/src/types/mainPage/mainbanner.ts
@@ -1,0 +1,37 @@
+export interface CrewMember {
+  adult: boolean;
+  gender: number;
+  id: number;
+  known_for_department: string;
+  name: string;
+  original_name: string;
+  popularity: number;
+  profile_path: string;
+  credit_id: string;
+  department: string;
+  job: string;
+}
+
+export interface CreditsType {
+  id: number;
+  cats: [];
+  crew: CrewMember[];
+}
+
+export interface VideoResultsType {
+  iso_639_1: string;
+  iso_3166_1: string;
+  name: string;
+  key: string;
+  site: string;
+  size: number;
+  type: string;
+  official: boolean;
+  published_at: string;
+  id: string;
+}
+
+export interface VideoType {
+  id: number;
+  results: VideoResultsType[];
+}


### PR DESCRIPTION
# 작업분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- 메인페이지 추가 api 연동
- 메인페이지 배너 유튜브 동영상 임배드 -> 추가 리팩토링 필요

# 작업 상세 내용
- 기존 목데이터 지우고 api 연동 완료
- 유튜브 key가 있는 api 가져와서 임베드 

https://github.com/user-attachments/assets/e87c23f4-2008-470d-91f7-a376e2dd98c3



# 리뷰 요구사항
- 아직 배너에 다음동영상 버튼을 누르면 넘어가는 기능을 완료하진 못했습니다.
- 추후 해당 기능 구현하고 pr 올리도록 하겠습니다.

# 연관된 Jira 티켓 번호
- #16 
