### PR TITLE
feat: 모달 예고편 페이지 구현

### DIFF
--- a/moving/src/components/detail/DetailModal.tsx
+++ b/moving/src/components/detail/DetailModal.tsx
@@ -28,8 +28,10 @@ export default function DetailModal({ isOpacity }: DetailModalProps) {
   ];
   const router = useRouter();
   const { movieNumber } = router.query;
-  const [tabIsActive, setTabIsActive] = useState(0);
+  console.log(movieNumber);
   const { modalAnimate, modalAnimateActive } = useModalAnimateStore();
+  const [movieId, setMovieId] = useState<number | null>(null);
+  const [tabIsActive, setTabIsActive] = useState(0);
   const {
     movieQuery,
     creditQuery,
@@ -42,6 +44,12 @@ export default function DetailModal({ isOpacity }: DetailModalProps) {
 
   // 영화 개봉년도
   const movieYear = new Date(movieQuery.data?.release_date).getFullYear();
+
+  useEffect(() => {
+    if (movieNumber) {
+      setMovieId(Number(movieNumber)); // movieNumber가 정의되었을 때만 변환
+    }
+  }, [movieNumber]);
 
   useEffect(() => {
     setTimeout(() => {
@@ -60,7 +68,8 @@ export default function DetailModal({ isOpacity }: DetailModalProps) {
     creditQuery.isLoading ||
     reviewQuery.isLoading ||
     recommendationQuery.isLoading ||
-    trailerQuery.isLoading
+    trailerQuery.isLoading ||
+    !movieNumber
   ) {
     return <div>로딩중...</div>;
   }
@@ -116,7 +125,9 @@ export default function DetailModal({ isOpacity }: DetailModalProps) {
             )}
 
             <li className="mb-6 mt-4 flex h-7 items-center justify-center rounded-xl border-[1px] border-white bg-[rgba(43,45,49,0.8)] px-4 text-xs font-normal text-white">
-              {ageQuery.data.certification}세
+              {ageQuery.data?.certification === 'ALL'
+                ? ageQuery.data?.certification
+                : ageQuery.data?.certification + '세'}
             </li>
             {movieQuery.data.genres.map(
               (genre: { id: number; name: string }) => {

--- a/moving/src/components/detail/DetailModal.tsx
+++ b/moving/src/components/detail/DetailModal.tsx
@@ -17,6 +17,9 @@ import {
   fetchSeriesData,
   fetchTrailerData,
 } from '@/lib/apis/modal/api';
+import TrailerTab from './components/TrailerTab';
+import clsx from 'clsx';
+import { useModalAnimateStore } from '@/lib/store/modalAnimateStore';
 import { useRouter } from 'next/router';
 
 interface DetailModalProps {
@@ -25,9 +28,16 @@ interface DetailModalProps {
 
 export default function DetailModal({ isOpacity }: DetailModalProps) {
   const reviewFavoriteClass = 'flex items-center gap-2 text-xs text-white';
-  const MOVIE_TAB_LIST = ['시리즈', '연관작품', '사용자 평', '상세정보'];
+  const MOVIE_TAB_LIST = [
+    '시리즈',
+    '연관작품',
+    '사용자 평',
+    '상세정보',
+    '예고편',
+  ];
   const [tabIsActive, setTabIsActive] = useState(0);
   const [movieId, setMovieId] = useState<number>(1159311);
+  const { modalAnimate, resetModalAnimate } = useModalAnimateStore();
   const router = useRouter();
 
   // 영화 데이터
@@ -140,11 +150,19 @@ export default function DetailModal({ isOpacity }: DetailModalProps) {
 
   const movieYear = new Date(movieData?.release_date).getFullYear(); // 영화 개봉년도
 
+  // const resetModalAnimation = () => {
+  //   setModalAnimate(false);
+  // };
+
   useEffect(() => {
     setTimeout(() => {
       setTabIsActive(0);
     }, 500);
   }, [isOpacity]);
+
+  // useEffect(() => {
+  //   setModalAnimate(true);
+  // }, [modalAnimate]);
 
   if (
     movieIsLoading ||
@@ -173,7 +191,10 @@ export default function DetailModal({ isOpacity }: DetailModalProps) {
   return (
     <div className="relative mx-auto w-full max-w-[1080px] bg-[#000000]">
       <div
-        className="mb-20 animate-zoomBg bg-cover bg-center bg-no-repeat px-20 pt-7"
+        className={clsx(
+          'mb-20 bg-cover bg-center bg-no-repeat px-20 pt-7',
+          modalAnimate && 'animate-zoomBg'
+        )}
         style={{
           backgroundImage: `linear-gradient(to top, rgba(0, 0, 0, 0.9) 10%, rgba(0, 0, 0, 0.4) 100%), url(${process.env.NEXT_PUBLIC_BACK_IMAGE_URL}${movieData.backdrop_path})`,
         }}
@@ -288,6 +309,9 @@ export default function DetailModal({ isOpacity }: DetailModalProps) {
               creditData={creditData}
             />
           );
+        })
+        .with(4, () => {
+          return <TrailerTab trailerKey={trailerData.key} />;
         })
         .otherwise(() => {
           return <SeriesTab seriesData={seriesData} setMovieId={setMovieId} />;

--- a/moving/src/components/detail/DetailModal.tsx
+++ b/moving/src/components/detail/DetailModal.tsx
@@ -30,7 +30,6 @@ export default function DetailModal({ isOpacity }: DetailModalProps) {
   const { movieNumber } = router.query;
   console.log(movieNumber);
   const { modalAnimate, modalAnimateActive } = useModalAnimateStore();
-  const [movieId, setMovieId] = useState<number | null>(null);
   const [tabIsActive, setTabIsActive] = useState(0);
   const {
     movieQuery,
@@ -44,12 +43,6 @@ export default function DetailModal({ isOpacity }: DetailModalProps) {
 
   // 영화 개봉년도
   const movieYear = new Date(movieQuery.data?.release_date).getFullYear();
-
-  useEffect(() => {
-    if (movieNumber) {
-      setMovieId(Number(movieNumber)); // movieNumber가 정의되었을 때만 변환
-    }
-  }, [movieNumber]);
 
   useEffect(() => {
     setTimeout(() => {

--- a/moving/src/components/detail/components/RelatedWorksTab.tsx
+++ b/moving/src/components/detail/components/RelatedWorksTab.tsx
@@ -1,3 +1,5 @@
+import { useModal } from '@/lib/hook/useModal';
+import { useModalAnimateStore } from '@/lib/store/modalAnimateStore';
 import { useModalStore } from '@/lib/store/modalStore';
 import { movieImage } from '@/lib/utils/movieImage';
 import { RelatedWork } from '@/types/detail/type';
@@ -5,16 +7,17 @@ import Image from 'next/image';
 
 interface RelatedWorksTabProps {
   recommendationData: RelatedWork;
-  setMovieId: React.Dispatch<React.SetStateAction<number>>;
   setTabIsActive: React.Dispatch<React.SetStateAction<number>>;
 }
 
 export default function RelatedWorksTab({
   recommendationData,
-  setMovieId,
   setTabIsActive,
 }: RelatedWorksTabProps) {
   const { setScrollTop } = useModalStore();
+  const { handleModalChange } = useModal();
+  const { resetModalAnimate } = useModalAnimateStore();
+
   return (
     <div className="grid grid-cols-[repeat(6,1fr)] gap-x-6 gap-y-9 px-20 pb-10 text-white">
       {recommendationData.results.map((result) => {
@@ -24,7 +27,8 @@ export default function RelatedWorksTab({
             <div
               className="mb-2 flex-shrink-0 cursor-pointer"
               onClick={() => {
-                setMovieId(result.id);
+                handleModalChange(result.id);
+                resetModalAnimate();
                 setTabIsActive(0);
                 setScrollTop();
               }}

--- a/moving/src/components/detail/components/SeriesTab.tsx
+++ b/moving/src/components/detail/components/SeriesTab.tsx
@@ -1,60 +1,70 @@
+import { useModal } from '@/lib/hook/useModal';
+import { useModalAnimateStore } from '@/lib/store/modalAnimateStore';
 import { useModalStore } from '@/lib/store/modalStore';
 import { SeriesData } from '@/types/detail/type';
 import Image from 'next/image';
 
 interface SeriesTabProps {
   seriesData: SeriesData;
-  setMovieId: React.Dispatch<React.SetStateAction<number>>;
 }
 
-export default function SeriesTab({ seriesData, setMovieId }: SeriesTabProps) {
+export default function SeriesTab({ seriesData }: SeriesTabProps) {
   const { setScrollTop } = useModalStore();
+  const { handleModalChange } = useModal();
+  const { resetModalAnimate } = useModalAnimateStore();
 
   return (
     <div className="px-20 pb-10 text-white">
-      {seriesData?.parts
-        .sort(
-          (a, b) =>
-            new Date(a.release_date).getTime() -
-            new Date(b.release_date).getTime()
-        )
-        .map((part) => {
-          const movieYear = new Date(part.release_date).getFullYear();
-          const posterImage =
-            process.env.NEXT_PUBLIC_BACK_IMAGE_URL + part.poster_path;
+      {seriesData?.parts?.length > 0 ? (
+        seriesData.parts
+          .sort(
+            (a, b) =>
+              new Date(a.release_date).getTime() -
+              new Date(b.release_date).getTime()
+          )
+          .map((part) => {
+            const movieYear = new Date(part.release_date).getFullYear();
+            const posterImage =
+              process.env.NEXT_PUBLIC_BACK_IMAGE_URL + part.poster_path;
 
-          return (
-            <div
-              key={part.id}
-              className="relative mb-12 flex w-[100%] gap-4 border-b-2 border-[#2D313A] pb-12"
-            >
+            return (
               <div
-                className="flex-shrink-0 cursor-pointer"
-                onClick={() => {
-                  setMovieId(part.id);
-                  setScrollTop();
-                }}
+                key={part.id}
+                className="relative mb-12 flex w-[100%] gap-4 border-b-2 border-[#2D313A] pb-12"
               >
-                <Image
-                  src={posterImage}
-                  width={130}
-                  height={178}
-                  alt={`${part.title} 포스터 이미지`}
-                />
-              </div>
-              <div className="basis-[80%] pr-20">
-                <h3 className="mb-1 text-xl font-bold">{part.title}</h3>
-                <div className="mb-4 flex items-center gap-3">
-                  <span className="text-base font-medium">({movieYear})</span>
-                  <span className="rounded-lg border-[1px] border-[#F29B2E] px-3 py-[2px] text-sm font-normal text-[#F29B2E]">
-                    Hero
-                  </span>
+                <div
+                  className="flex-shrink-0 cursor-pointer"
+                  onClick={() => {
+                    handleModalChange(part.id);
+                    resetModalAnimate();
+                    setScrollTop();
+                  }}
+                >
+                  <Image
+                    src={posterImage}
+                    width={130}
+                    height={178}
+                    alt={`${part.title} 포스터 이미지`}
+                  />
                 </div>
-                <p className="line-clamp-3">{part.overview}</p>
+                <div className="basis-[80%] pr-20">
+                  <h3 className="mb-1 text-xl font-bold">{part.title}</h3>
+                  <div className="mb-4 flex items-center gap-3">
+                    <span className="text-base font-medium">({movieYear})</span>
+                    <span className="rounded-lg border-[1px] border-[#F29B2E] px-3 py-[2px] text-sm font-normal text-[#F29B2E]">
+                      Hero
+                    </span>
+                  </div>
+                  <p className="line-clamp-3">{part.overview}</p>
+                </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })
+      ) : (
+        <div className="flex h-[300px] w-full items-center justify-center">
+          시리즈가 없습니다.
+        </div>
+      )}
     </div>
   );
 }

--- a/moving/src/components/detail/components/TrailerTab.tsx
+++ b/moving/src/components/detail/components/TrailerTab.tsx
@@ -1,0 +1,29 @@
+import clsx from 'clsx';
+
+interface TrailerTabProps {
+  trailerKey: string | undefined;
+}
+
+export default function TrailerTab({ trailerKey }: TrailerTabProps) {
+  return (
+    <div
+      className={clsx(
+        'flex w-full items-center justify-center px-20 pb-10 text-white',
+        trailerKey ? 'h-[500px]' : 'h-[300px]'
+      )}
+    >
+      {trailerKey ? (
+        <iframe
+          width="100%"
+          height="100%"
+          src={`https://www.youtube.com/embed/${trailerKey}?autoplay=1`}
+          title="예고편"
+          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+        />
+      ) : (
+        <p>제공되는 예고편이 없습니다.</p>
+      )}
+    </div>
+  );
+}

--- a/moving/src/components/detail/components/UserReviewsTab.tsx
+++ b/moving/src/components/detail/components/UserReviewsTab.tsx
@@ -57,57 +57,62 @@ export default function UserReviewsTab({
         />
       </div>
 
-      <div className="mb-12 flex items-center justify-between">
-        <span>리뷰 ({reviewData.total_results})</span>
-      </div>
-
-      {reviewData.results.map((result) => {
-        const profileImage = movieImage(result.author_details.avatar_path);
-        const reviewStar = Math.floor(result.author_details.rating / 2);
-        return (
-          <div
-            key={result.id}
-            className="mb-10 border-b-2 border-[#2D313A] pb-10"
-          >
-            <div className="mb-4 flex justify-between">
-              <div>
-                <div className="mb-3 flex items-center gap-2 text-sm font-normal">
-                  <Image
-                    src={profileImage}
-                    width={33}
-                    height={33}
-                    className="h-[33px] w-[33px] rounded-full"
-                    alt="프로필 이미지"
-                  />
-                  {result.author_details.username}
-                </div>
-                <div className="mb-3 flex items-center gap-1">
-                  {Array.from({ length: MAX_STAR }, (_, index) => {
-                    return (
-                      <span key={index}>
-                        <Image
-                          src={
-                            index > reviewStar - 1
-                              ? 'icons/starOutIcon.svg'
-                              : 'icons/starOnIcon.svg'
-                          }
-                          width={28}
-                          height={28}
-                          alt="별점 아이콘"
-                        />
-                      </span>
-                    );
-                  })}
-                </div>
-                <span className="text-xs font-normal text-[#77777777]">
-                  1개월 전
-                </span>
-              </div>
-            </div>
-            <p className="text-base font-normal">{result.content}</p>
+      {reviewData.results.length > 0 ? (
+        <>
+          <div className="mb-12 flex items-center justify-between">
+            <span>리뷰 ({reviewData.total_results})</span>
           </div>
-        );
-      })}
+          {reviewData.results.map((result) => {
+            const profileImage = movieImage(result.author_details.avatar_path);
+            const reviewStar = Math.floor(result.author_details.rating / 2);
+            return (
+              <div
+                key={result.id}
+                className="mb-10 border-b-2 border-[#2D313A] pb-10"
+              >
+                <div className="mb-4 flex justify-between">
+                  <div>
+                    <div className="mb-3 flex items-center gap-2 text-sm font-normal">
+                      <Image
+                        src={profileImage}
+                        width={33}
+                        height={33}
+                        className="h-[33px] w-[33px] rounded-full"
+                        alt="프로필 이미지"
+                      />
+                      {result.author_details.username}
+                    </div>
+                    <div className="mb-3 flex items-center gap-1">
+                      {Array.from({ length: MAX_STAR }, (_, index) => {
+                        return (
+                          <span key={index}>
+                            <Image
+                              src={
+                                index > reviewStar - 1
+                                  ? 'icons/starOutIcon.svg'
+                                  : 'icons/starOnIcon.svg'
+                              }
+                              width={28}
+                              height={28}
+                              alt="별점 아이콘"
+                            />
+                          </span>
+                        );
+                      })}
+                    </div>
+                    <span className="text-xs font-normal text-[#77777777]">
+                      1개월 전
+                    </span>
+                  </div>
+                </div>
+                <p className="text-base font-normal">{result.content}</p>
+              </div>
+            );
+          })}
+        </>
+      ) : (
+        <div className="text-center">작성된 리뷰가 없습니다.</div>
+      )}
     </div>
   );
 }

--- a/moving/src/lib/apis/modal/api.ts
+++ b/moving/src/lib/apis/modal/api.ts
@@ -59,17 +59,11 @@ export const fetchCreditData = async ({
 // 리뷰 데이터 가져오기
 export const fetchReviewData = async ({
   movieId = 912649,
-  language = 'ko-KR',
 }: {
   movieId: number;
-  language: string | null;
 }) => {
   try {
-    const response = await axiosInstance.get(`movie/${movieId}/reviews`, {
-      params: {
-        language,
-      },
-    });
+    const response = await axiosInstance.get(`movie/${movieId}/reviews`);
     return response.data;
   } catch (error) {
     console.log('리뷰 데이터 오류', error);

--- a/moving/src/lib/apis/modal/api.ts
+++ b/moving/src/lib/apis/modal/api.ts
@@ -1,11 +1,7 @@
 import { axiosInstance } from '../instance/axiosInstance';
 
 // 영화 데이터 가져오기
-export const fetchMovieData = async ({
-  movieId = 912649,
-}: {
-  movieId: number;
-}) => {
+export const fetchMovieData = async ({ movieId }: { movieId: number }) => {
   try {
     const response = await axiosInstance.get(`movie/${movieId}`);
     return response.data;
@@ -16,7 +12,7 @@ export const fetchMovieData = async ({
 
 // 연령 제한 데이터 가져오기
 export const fetchCertificationData = async ({
-  movieId = 912649,
+  movieId,
 }: {
   movieId: number;
 }) => {
@@ -30,7 +26,7 @@ export const fetchCertificationData = async ({
 
 // 시리즈 데이터 가져오기
 export const fetchSeriesData = async ({
-  collectionId = 558216,
+  collectionId,
 }: {
   collectionId: number;
 }) => {
@@ -43,11 +39,7 @@ export const fetchSeriesData = async ({
 };
 
 // 출연진 데이터 가져오기
-export const fetchCreditData = async ({
-  movieId = 912649,
-}: {
-  movieId: number;
-}) => {
+export const fetchCreditData = async ({ movieId }: { movieId: number }) => {
   try {
     const response = await axiosInstance.get(`movie/${movieId}/credits`);
     return response.data;
@@ -57,11 +49,7 @@ export const fetchCreditData = async ({
 };
 
 // 리뷰 데이터 가져오기
-export const fetchReviewData = async ({
-  movieId = 912649,
-}: {
-  movieId: number;
-}) => {
+export const fetchReviewData = async ({ movieId }: { movieId: number }) => {
   try {
     const response = await axiosInstance.get(`movie/${movieId}/reviews`);
     return response.data;
@@ -72,7 +60,7 @@ export const fetchReviewData = async ({
 
 // 관련작품 데이터 가져오기
 export const fetchRecommendationData = async ({
-  movieId = 912649,
+  movieId,
 }: {
   movieId: number;
 }) => {
@@ -87,11 +75,7 @@ export const fetchRecommendationData = async ({
 };
 
 // 예고편 데이터 가져오기
-export const fetchTrailerData = async ({
-  movieId = 1159311,
-}: {
-  movieId: number;
-}) => {
+export const fetchTrailerData = async ({ movieId }: { movieId: number }) => {
   try {
     const response = await axiosInstance.get(`movie/${movieId}/videos`);
     return response.data;

--- a/moving/src/lib/hook/useModal.ts
+++ b/moving/src/lib/hook/useModal.ts
@@ -1,18 +1,36 @@
 import { useState } from 'react';
+import { useRouter } from 'next/router';
 
 export const useModal = () => {
   const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
   const [isOpacity, setIsOpacity] = useState<boolean>(false);
+  const router = useRouter();
 
-  const handleModalOpen = () => {
+  const handleModalOpen = (id: number) => {
+    router.replace({
+      pathname: router.pathname,
+      query: { ...router.query, movieNumber: id },
+    });
     setIsOpenModal(true);
     setIsOpacity(true);
   };
 
+  const handleModalChange = (id: number) => {
+    router.replace({
+      pathname: router.pathname,
+      query: { ...router.query, movieNumber: id },
+    });
+  };
+
   const handleModalClose = () => {
+    const { movieNumber, ...restQueries } = router.query;
     setIsOpacity(false);
 
     setTimeout(() => {
+      router.replace({
+        pathname: router.pathname,
+        query: restQueries,
+      });
       setIsOpenModal(false);
     }, 500);
   };
@@ -21,6 +39,7 @@ export const useModal = () => {
     isOpenModal,
     isOpacity,
     handleModalOpen,
+    handleModalChange,
     handleModalClose,
   };
 };

--- a/moving/src/lib/hook/useModalData.ts
+++ b/moving/src/lib/hook/useModalData.ts
@@ -14,18 +14,21 @@ export const useModalData = (movieId: number) => {
   const movieQuery = useQuery({
     queryKey: ['movieData', movieId],
     queryFn: async () => await fetchMovieData({ movieId }),
+    enabled: !!movieId,
   });
 
   // 출연진 데이터
   const creditQuery = useQuery({
     queryKey: ['creditData', movieId],
     queryFn: async () => await fetchCreditData({ movieId }),
+    enabled: !!movieId,
   });
 
   // 리뷰 데이터
   const reviewQuery = useQuery({
     queryKey: ['reviewData', movieId],
     queryFn: async () => await fetchReviewData({ movieId }),
+    enabled: !!movieId,
   });
 
   // 예고편 데이터
@@ -35,12 +38,14 @@ export const useModalData = (movieId: number) => {
       const res = await fetchTrailerData({ movieId });
       return res.results.length < 1 ? false : res.results[0];
     },
+    enabled: !!movieId,
   });
 
   // 관련작품 데이터
   const recommendationQuery = useQuery({
     queryKey: ['recommendationData', movieId],
     queryFn: async () => await fetchRecommendationData({ movieId }),
+    enabled: !!movieId,
   });
 
   // 시리즈 데이터
@@ -51,6 +56,7 @@ export const useModalData = (movieId: number) => {
         collectionId: movieQuery.data?.belongs_to_collection.id,
       });
     },
+    enabled: !!movieId && !!movieQuery.data?.belongs_to_collection.id,
   });
 
   // 나이제한 데이터
@@ -65,6 +71,7 @@ export const useModalData = (movieId: number) => {
       );
       return krData.release_dates[0];
     },
+    enabled: !!movieId,
   });
 
   return {

--- a/moving/src/lib/hook/useModalData.ts
+++ b/moving/src/lib/hook/useModalData.ts
@@ -1,0 +1,79 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  fetchCertificationData,
+  fetchCreditData,
+  fetchMovieData,
+  fetchRecommendationData,
+  fetchReviewData,
+  fetchSeriesData,
+  fetchTrailerData,
+} from '../apis/modal/api';
+
+export const useModalData = (movieId: number) => {
+  // 영화 데이터
+  const movieQuery = useQuery({
+    queryKey: ['movieData', movieId],
+    queryFn: async () => await fetchMovieData({ movieId }),
+  });
+
+  // 출연진 데이터
+  const creditQuery = useQuery({
+    queryKey: ['creditData', movieId],
+    queryFn: async () => await fetchCreditData({ movieId }),
+  });
+
+  // 리뷰 데이터
+  const reviewQuery = useQuery({
+    queryKey: ['reviewData', movieId],
+    queryFn: async () => await fetchReviewData({ movieId }),
+  });
+
+  // 예고편 데이터
+  const trailerQuery = useQuery({
+    queryKey: ['trailerData', movieId],
+    queryFn: async () => {
+      const res = await fetchTrailerData({ movieId });
+      return res.results.length < 1 ? false : res.results[0];
+    },
+  });
+
+  // 관련작품 데이터
+  const recommendationQuery = useQuery({
+    queryKey: ['recommendationData', movieId],
+    queryFn: async () => await fetchRecommendationData({ movieId }),
+  });
+
+  // 시리즈 데이터
+  const seriesQuery = useQuery({
+    queryKey: ['seriesData', movieId],
+    queryFn: async () => {
+      return fetchSeriesData({
+        collectionId: movieQuery.data?.belongs_to_collection.id,
+      });
+    },
+  });
+
+  // 나이제한 데이터
+  const ageQuery = useQuery({
+    queryKey: ['ageData', movieId],
+    queryFn: async () => {
+      const res = await fetchCertificationData({ movieId });
+
+      const krData = res.results.find(
+        (key: { iso_3166_1: string }) =>
+          key.iso_3166_1 === 'KR' || key.iso_3166_1 === 'US'
+      );
+      return krData.release_dates[0];
+    },
+  });
+
+  return {
+    movieQuery,
+    creditQuery,
+    reviewQuery,
+    trailerQuery,
+    recommendationQuery,
+    seriesQuery,
+    ageQuery,
+  };
+};

--- a/moving/src/lib/store/modalAnimateStore.ts
+++ b/moving/src/lib/store/modalAnimateStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ModalAnimateStore {
+  modalAnimate: boolean;
+  resetModalAnimate: () => void;
+}
+
+export const useModalAnimateStore = create<ModalAnimateStore>((set) => ({
+  modalAnimate: false,
+  resetModalAnimate: () => set({ modalAnimate: false }),
+}));

--- a/moving/src/lib/store/modalAnimateStore.ts
+++ b/moving/src/lib/store/modalAnimateStore.ts
@@ -2,10 +2,12 @@ import { create } from 'zustand';
 
 interface ModalAnimateStore {
   modalAnimate: boolean;
+  modalAnimateActive: () => void;
   resetModalAnimate: () => void;
 }
 
 export const useModalAnimateStore = create<ModalAnimateStore>((set) => ({
   modalAnimate: false,
+  modalAnimateActive: () => set({ modalAnimate: true }),
   resetModalAnimate: () => set({ modalAnimate: false }),
 }));

--- a/moving/src/pages/test/index.tsx
+++ b/moving/src/pages/test/index.tsx
@@ -19,7 +19,6 @@ export default function ModalPage() {
     <>
       <button
         type="button"
-        id="912649"
         className="relative z-50"
         onClick={() => {
           handleModalOpen(1159311);
@@ -32,7 +31,7 @@ export default function ModalPage() {
         isOpacity={isOpacity}
         handleModalClose={handleModalClose}
       >
-        <DetailModal isOpacity={isOpacity} />
+        {isOpenModal && <DetailModal isOpacity={isOpacity} />}
       </ModalFrame>
     </>
   );

--- a/moving/src/pages/test/index.tsx
+++ b/moving/src/pages/test/index.tsx
@@ -1,13 +1,30 @@
 import DetailModal from '@/components/detail/DetailModal';
 import ModalFrame from '@/components/modal/ModalFrame';
 import { useModal } from '@/lib/hook/useModal';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 export default function ModalPage() {
   const { isOpenModal, isOpacity, handleModalOpen, handleModalClose } =
     useModal();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (router.query.movieNumber) {
+      const movieNumber = Number(router.query.movieNumber);
+      handleModalOpen(movieNumber);
+    }
+  }, []);
   return (
     <>
-      <button type="button" className="relative z-50" onClick={handleModalOpen}>
+      <button
+        type="button"
+        id="912649"
+        className="relative z-50"
+        onClick={() => {
+          handleModalOpen(1159311);
+        }}
+      >
         모달 열기
       </button>
       <ModalFrame

--- a/moving/src/pages/trailerPage/index.tsx
+++ b/moving/src/pages/trailerPage/index.tsx
@@ -4,7 +4,16 @@ export default function TrailerPage() {
   const router = useRouter();
   const { trailerKey } = router.query;
   return (
-    <div className="h-screen w-screen">
+    <div className="relative h-screen w-screen">
+      <button
+        type="button"
+        className="absolute left-6 top-6 z-50 text-4xl"
+        onClick={() => {
+          router.back();
+        }}
+      >
+        〈
+      </button>
       <iframe
         width="100%"
         height="100%"


### PR DESCRIPTION
# 작업분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 리팩토링
- [ ] 기타

# 작업개요
- 모달 예고편 페이지 구현
- useQuery 커스텀 훅으로 구현
- 애니메이션 상태 전역으로 관리

# 작업 상세 내용
- 모달에서 시청하기 클릭시 예고편 시청 페이지로 이동(url에 예고편 key를 받아와서 노출)
- 뒤로가기 버튼 클릭시 기존에 열려있던 모달 상태 그대로 페이지 노출
  - 모달의 id값을 클릭시 받아오는게 아닌 url 쿼리에 저장해서 가져오도록 구현(브라우저 뒤로가기, 버튼 뒤로가기 동일하게 동작)
- 모달 이미지 애니메이션이 한번만 동작하여 영화가 변경 될때마다 구현되도록 애니메이션의 상태를 전역으로 관리
- 모달 내부 데이터들을 가져오는 useQuery를 가독성을 위해 커스텀 훅으로 구현

https://github.com/user-attachments/assets/451b4fb7-3c01-4d3e-bacd-37e1a94f1495

# 리뷰 요구사항
_집중 리뷰 부분 작성_

# 연관된 Jira 티켓 번호
- #22 
